### PR TITLE
feat: transform kubeconfig into cluster internally addressable

### DIFF
--- a/gin-next/plans/plan.cue
+++ b/gin-next/plans/plan.cue
@@ -9,15 +9,26 @@ import (
 
 dagger.#Plan & {
 	client: {
-		commands: kubeconfig: {
-			name: "cat"
-			args: ["\(env.KUBECONFIG)"]
-			stdout: dagger.#Secret
+		commands: {
+			if env.KUBECONFIG != "" {
+				kubeconfig: {
+					name: "sh"
+					args: ["-c", "cat \(env.KUBECONFIG) | sed -e 's?server: https://.*?server: https://kubernetes.default.svc?'"]
+					stdout: dagger.#Secret
+				}
+			}
+			if env.KUBECONFIG == "" {
+				kubeconfig: {
+					name: "sh"
+					args: ["-c", "kubectl config view --flatten --minify | sed -e 's?server: https://.*?server: https://kubernetes.default.svc?'"]
+					stdout: dagger.#Secret
+				}
+			}
 		}
 		env: {
 			ORGANIZATION:   string
 			GITHUB_TOKEN:   dagger.#Secret
-			KUBECONFIG:     string
+			KUBECONFIG:     string | *""
 			CLOUD_PROVIDER: string
 			APP_NAME:       string
 		}


### PR DESCRIPTION
Currently the stack requires users to manually _sed_ the kubeconfig before running the stack. We can do this inside the stack.

Secondly, this also implements the idea from https://github.com/h8r-dev/heighliner/issues/115:
- If KUBECONFIG env is set, use KUBECONFIG
- Otherwise, use the output from `kubectl config view --flatten --minify`